### PR TITLE
Added StateInfoByte to SpawnOneShotFFX for Sekiro

### DIFF
--- a/DSAnimStudio/Res/TAE.Template.SDT.xml
+++ b/DSAnimStudio/Res/TAE.Template.SDT.xml
@@ -329,7 +329,7 @@
       <b name="IsFollowDummyPoly"/>
       <b name="IsRestrictToDummyPoly"/>
       <u8 name="ExtraSpawnCondition"/>
-      <u8 name="StateInfo"/>
+      <s16 name="StateInfo"/>
     </event>
     <event id="99" name="SpawnRepeatingFFX">
       <s32 name="FFXID"/>

--- a/DSAnimStudio/Res/TAE.Template.SDT.xml
+++ b/DSAnimStudio/Res/TAE.Template.SDT.xml
@@ -329,6 +329,7 @@
       <b name="IsFollowDummyPoly"/>
       <b name="IsRestrictToDummyPoly"/>
       <u8 name="ExtraSpawnCondition"/>
+      <u8 name="StateInfoByte"/>
     </event>
     <event id="99" name="SpawnRepeatingFFX">
       <s32 name="FFXID"/>

--- a/DSAnimStudio/Res/TAE.Template.SDT.xml
+++ b/DSAnimStudio/Res/TAE.Template.SDT.xml
@@ -329,7 +329,7 @@
       <b name="IsFollowDummyPoly"/>
       <b name="IsRestrictToDummyPoly"/>
       <u8 name="ExtraSpawnCondition"/>
-      <u8 name="StateInfoByte"/>
+      <u8 name="StateInfo"/>
     </event>
     <event id="99" name="SpawnRepeatingFFX">
       <s32 name="FFXID"/>


### PR DESCRIPTION
Fixes VFX breaking on save.

Tested with mods on all enemy bosses and player VFX.