### PR TITLE
Fixed crash that happened when trying to load Sekiro c5080 and c5090

### DIFF
--- a/DSAnimStudio/FlverSubmeshRenderer.cs
+++ b/DSAnimStudio/FlverSubmeshRenderer.cs
@@ -365,13 +365,19 @@ namespace DSAnimStudio
                 if (GameDataManager.GameType == SoulsAssetPipeline.SoulsGames.SDT)
                 {
                     var mtdTex = GameDataManager.LookupMTDTexture(flvr.Materials[mesh.MaterialIndex].MTD, matParam.Type);
-                    shortTexPath = Utils.GetShortIngameFileName(mtdTex.Path).ToLower();
-
+                    
                     texScaleVal /= mtdTex.UVScale;
 
-                    if (string.IsNullOrWhiteSpace(shortTexPath))
+                    // This can be null so store it first to check before accessing it
+                    string mtdTexShortFilename = Utils.GetShortIngameFileName(mtdTex.Path);
+                    if (string.IsNullOrWhiteSpace(mtdTexShortFilename))
                     {
                         shortTexPath = Utils.GetShortIngameFileName(matParam.Path).ToLower();
+                    }
+                    else
+                    {
+                        // We only want to use this if mtdTexShortFilename is valid, if not we will crash
+                        shortTexPath = mtdTexShortFilename.ToLower();
                     }
                 }
 

--- a/DSAnimStudio/Res/TAE.Template.SDT.xml
+++ b/DSAnimStudio/Res/TAE.Template.SDT.xml
@@ -329,7 +329,7 @@
       <b name="IsFollowDummyPoly"/>
       <b name="IsRestrictToDummyPoly"/>
       <u8 name="ExtraSpawnCondition"/>
-      <u8 name="StateInfo"/>
+      <s16 name="StateInfo"/>
     </event>
     <event id="99" name="SpawnRepeatingFFX">
       <s32 name="FFXID"/>

--- a/DSAnimStudio/Res/TAE.Template.SDT.xml
+++ b/DSAnimStudio/Res/TAE.Template.SDT.xml
@@ -329,6 +329,7 @@
       <b name="IsFollowDummyPoly"/>
       <b name="IsRestrictToDummyPoly"/>
       <u8 name="ExtraSpawnCondition"/>
+      <u8 name="StateInfoByte"/>
     </event>
     <event id="99" name="SpawnRepeatingFFX">
       <s32 name="FFXID"/>

--- a/DSAnimStudio/Res/TAE.Template.SDT.xml
+++ b/DSAnimStudio/Res/TAE.Template.SDT.xml
@@ -329,7 +329,7 @@
       <b name="IsFollowDummyPoly"/>
       <b name="IsRestrictToDummyPoly"/>
       <u8 name="ExtraSpawnCondition"/>
-      <u8 name="StateInfoByte"/>
+      <u8 name="StateInfo"/>
     </event>
     <event id="99" name="SpawnRepeatingFFX">
       <s32 name="FFXID"/>

--- a/DSAnimStudio/packages.config
+++ b/DSAnimStudio/packages.config
@@ -23,7 +23,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net47" />
   <package id="System.Linq" version="4.3.0" targetFramework="net47" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net47" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net47" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net47" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net47" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net47" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net47" />


### PR DESCRIPTION
When trying to open Sekiro Gyobu Oniwa or Lady Butterfly animation files DS Anim Studio was crashing.
The crash was due to an access to a null object before checking it.