### PR TITLE
Launch DSAS from URI via protocol handler

### DIFF
--- a/DSAnimStudioNETCore/DSASURILoader.cs
+++ b/DSAnimStudioNETCore/DSASURILoader.cs
@@ -1,0 +1,94 @@
+﻿using SharpDX.Direct3D11;
+using System;
+using System.Diagnostics;
+using System.Web;
+
+namespace DSAnimStudio
+{
+    /**
+     * URI format is:
+     * dsas://<action>?param1=<value1>&param2=<value>
+     * e.g. dsas://load
+     */
+    public class DSASURILoader
+    {
+        Uri ParsedURI;
+        System.Collections.Specialized.NameValueCollection ParsedQuery;
+        TaeEditor.TaeEditorScreen TAE_EDITOR;
+
+        public DSASURILoader(string InputURI, TaeEditor.TaeEditorScreen TaeEditor)
+        {
+            ParsedURI = new Uri(InputURI);
+            ParsedQuery = HttpUtility.ParseQueryString(ParsedURI.Query);
+            TAE_EDITOR = TaeEditor;
+        }
+
+        public static bool IsValid(string UriToCheck)
+        {
+            return UriToCheck.StartsWith("dsas://");
+        }
+
+        public bool Process()
+        {
+            switch (ParsedURI.Host)
+            {
+                case "open":
+                    {
+                        if (ParsedQuery.Get("suppress_prompts") != null)
+                        {
+                            GameRoot.SuppressNextInterrootBrowsePrompt = true;
+                            TAE_EDITOR.SuppressNextModelOverridePrompt = true;
+                        }
+
+                        if (ParsedQuery.Get("c") != null)
+                        {
+                            TAE_EDITOR.FileContainerName = ParsedQuery.Get("c");
+                        }
+
+                        if (ParsedQuery.Get("chr") != null)
+                        {
+                            TAE_EDITOR.FileContainerName_Model = ParsedQuery.Get("chr");
+                        }
+
+                        var MostRecentContainer = Main.Config.RecentFilesList[0];
+
+                        if (MostRecentContainer != null && TAE_EDITOR.FileContainerName == "")
+                        {
+                            TAE_EDITOR.FileContainerName = MostRecentContainer.TaeFile;
+                        }
+
+                        if (TAE_EDITOR.FileContainerName_Model == "")
+                        {
+                            if (MostRecentContainer.ModelFile != null)
+                            {
+                                TAE_EDITOR.FileContainerName_Model = MostRecentContainer.ModelFile;
+                            }
+                            else
+                            {
+                                TAE_EDITOR.FileContainerName_Model = "/chr/c0000.chrbnd.dcx";
+                            }
+                        }
+
+                        LoadingTaskMan.DoLoadingTask("DSASURILoader", "Loading ANIBND and associated model(s) from URI...", progress =>
+                        {
+                            TAE_EDITOR.LoadCurrentFile();
+
+                            var GoToAnimationIdParam = ParsedQuery.Get("id");
+                            if (GoToAnimationIdParam != null)
+                            {
+                                string GoToAnimationIdString = GoToAnimationIdParam.Replace("_", "").Replace("a", "");
+                                if (int.TryParse(GoToAnimationIdString, out int id))
+                                {
+                                    TAE_EDITOR.GotoAnimID(id, true, true, out _);
+                                }
+                            }
+                        }, disableProgressBarByDefault: true);
+
+                        return true;
+                    }
+            }
+
+            return false;
+        }
+    }
+}

--- a/DSAnimStudioNETCore/ImguiOSD/MenuBar.cs
+++ b/DSAnimStudioNETCore/ImguiOSD/MenuBar.cs
@@ -144,6 +144,7 @@ namespace DSAnimStudio.ImguiOSD
                 bool clickedSaveConfigManually = ClickItem("Save Config File");
                 Main.DisableConfigFileAutoSave = !Checkbox("Enable Config File Autosaving", !Main.DisableConfigFileAutoSave);
                 bool clickedLoadConfigManually = ClickItem("Reload Config File");
+                bool clickedToggleRegisterProtocolHandler = ClickItem(Main.IsProtocolHandlerInstalled() ? "Unregister Protocol Handler" : "Register Protocol Handler");
 
                 ImGui.Separator();
                 bool clickedExit = ClickItem("Exit");
@@ -223,6 +224,17 @@ namespace DSAnimStudio.ImguiOSD
                     if (clickedLoadConfigManually)
                     {
                         Main.LoadConfig(isManual: true);
+                    }
+
+                    if (clickedToggleRegisterProtocolHandler)
+                    {
+                        if (Main.IsProtocolHandlerInstalled())
+                        {
+                            Main.UnregisterProtocolHandler();
+                        } else
+                        {
+                            Main.RegisterProtocolHandler();
+                        }
                     }
 
                     if (clickedExit)


### PR DESCRIPTION
DS Anim Studio can now be launched with one (or more) `dsas://` command line argument to presetup the application, and can also be extended in the future to support more things. This can be used to launch the program from a browser link.

The URI scheme is as follows:

```
dsas://<action>?<param1>=<value1>&<param2>=<value2>
```

The branch includes an `open` action accepting the following query params:

* `id`: ID of an animation to go to after the editor finished loading, e.g. 34033070 opens a034_033070.hkt
* `chr`: path to the character to load, like /chr/cXXX.chrbnd.dcx
* `c`: path of container file to load
* `suppress_prompts`: prevents project and character prompts from appearing

`chr` and `c` default to the relevant values from the most recent file. All parameters are optional.

Examples: dsas://open?id=a034_033070&chr=/chr/c0000.chrbnd.dcx&suppress_prompts=1 opens DS Anim Studio with no prompts, loads character c0000 and locates a034_033070.hkt.

In the File menu, there is now an option to register or unregister DS Anim Studio as a protocol handler.
